### PR TITLE
Gradual deploy - Versions and Aliases

### DIFF
--- a/gradual-deploy/README.md
+++ b/gradual-deploy/README.md
@@ -1,0 +1,389 @@
+# Step Functions Gradual Deployments
+These are reference scripts to demonstrate how to do gradual deployments using
+AWS Step Functions versions and aliases.
+
+You can use these scripts as inspiration to provision your own gradual
+deployments in your CI/CD environments of choice.
+
+The Python example shows how to use an AWS SDK to manage a gradual deployment,
+whereas the Bash script shows which AWS CLI commands you can use if you prefer. 
+An alternative is to [use CloudFormation for Step Functions Gradual Deployments](TODO: Linkhere).
+
+## Python API example
+### Prerequisites
+Since this is a Python script, you need the Python 3 runtime.
+
+To run [sfndeploy.py](sfndeploy.py), you will need to
+[install boto3](https://aws.amazon.com/sdk-for-python/) and
+[configure it with your 
+credentials](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html#configuration).
+
+tldr; `pip install boto3`
+
+### Script Overview
+[sfndeploy.py](sfndeploy.py) is a Python 3 script showing how to use the
+[boto3](https://aws.amazon.com/sdk-for-python/) AWS SDK for Python to create
+gradual deployments with Step Functions.
+
+This script demonstrates the following deployment strategies:
+1. Canary - route a small percentage of traffic to the new version initially,
+   then after a validation period where no alarms trigger, switch 100% to that
+   new version.
+2. Linear (aka Rolling) - route a percentage of traffic, which increases over
+   time from 0% to 100%, to the new version, rolling back immediately if any
+   alarms trigger.
+3. All at Once (aka Blue/Green) - immediately switch 100% to the new version,
+   monitor the new version and roll-back automatically to the previous version
+   if any alarms trigger. 
+
+### Canary
+A Canary strategy deploys in two steps: first a small increment of traffic
+routes to the new version, and if there are no problems during the set testing
+period it will switch 100% of traffic to the new version.
+
+In this script, use `--increment` to set the initial percentage of traffic to
+route to the new version. The `--interval` input specifies for how long (in
+seconds) the Canary testing period lasts before switching 100% of traffic to
+the new version.
+
+#### Example with defaults
+Here is an example showing a Canary deploy using the defaults for increment
+(5) and interval (120 seconds):
+```
+ ./sfndeploy.py --state-machine my-state-machine --region us-east-1 --alias=my-alias --file my-dir/sample.asl.json --publish-revision --strategy canary
+```
+This example will:
+- Upload the `sample.asl.json` file as a new revision of the state machine.
+- Publish the state machine definition you just uploaded as the next version.
+- Initially point 5% of traffic to this new version, using the `my-alias` alias.
+  You can change the percentage of traffic with the `--increment` argument.
+- Wait for the default period of 120s You can change this value with the
+  `--interval` input.
+- Switch 100% of traffic to the new version.
+
+#### Example with values for increment and interval
+Now let's switch 30% of traffic to the new version for a test period of
+300 seconds. During the 300s the scripts monitors two different alarms - if
+any of these alarms trigger the deployment will rollback. If the 300s complete
+with no alarms, the script switches 100% of traffic to the new version.
+
+```
+./sfndeploy.py --state-machine my-state-machine --region us-east-1 --alias=my-alias --publish-revision --strategy canary --increment 30 --interval 300 --alarms MaxCPU "API Error Breach"
+```
+
+Note in this script invocation there the optional file argument isn't specified,
+so the `--publish-revision` flag will publish the latest revision of the
+state machine to the new version without uploading a new definition.
+
+### Linear
+A Linear (or Rolling) deployment strategy gradually increases the percentage of
+traffic to the new state machine version from 0% to 100%, in regular increments.
+
+For example, an `--increment 20` with `--interval 600` will increase traffic
+by 20% every 600 seconds until the new version receives 100% of traffic.
+
+If you set `--alarms`, the script will monitor the alarms specified during the
+deployment until all traffic routes 100% to the new version. If any of the
+alarms go into the `ALARM` state during the deployment window, the script will
+automatically and immediately rollback to the previous version. You can
+configure how often the script polls for alarms with `--alarm-polling`.
+
+```
+./sfndeploy.py --state-machine my-state-machine --region us-east-1 --alias=my-alias --file my-dir/sample.asl.json --publish-revision --strategy linear --increment 20 --interval=600 --alarms MaxCPU "API Error Breach" --history-max 11
+```
+
+This example will:
+- Upload the `sample.asl.json` file as a new revision of the state machine.
+- Publish the state machine revision created in the previous step as the next
+  version.
+- Route 20% of traffic to the new version for 600s.
+- Increase the percentage of traffic directed to new new version by 20% each
+  600 seconds.
+- Monitor the 2 alarms every minute, and rollback automatically if an alarm
+  sounds.
+- The script will then delete historic versions prior to 11 versions ago.
+
+The `increment` does not need to be a factor of 100. The script will increment
+linearly until it reaches 100. The script caps the maximum weight at 100. If,
+for example, you set `increment` to 15, the script will increment in seven
+steps - six steps of 15 to reach weight 90, and then the final step would only
+add ten to reach 100. There wouldn't be any further increments in this case.
+
+### All at Once
+An All at Once strategy routes 100% of traffic to the new version immediately,
+then monitors for problems duirngs a configurable period. This is useful to
+support Blue/Green style deployment where you test the Green version first, then
+switch all your production traffic to that version. If any alarms trigger,
+the script will automatically rollback the alias to point to the Blue version.
+
+You can set the monitoring period with `--interval` (in seconds).
+
+This deployment strategy ignores the `--increment` input.
+
+```
+./sfndeploy.py --state-machine my-state-machine --region us-east-1 --alias=my-alias --file my-dir/sample.asl.json --publish-revision --strategy allatonce --interval=500 --alarms MaxCPU "API Error Breach" --history-max 10
+```
+
+This example will:
+- Upload the `sample.asl.json` file as a new revision of the state machine.
+- Publish the state machine you just uploaded as the next version.
+- Point 100% of traffic to this new version, using the alias.
+- Monitor the two alarms for 500s, and rollback automatically if an alarm
+  sounds.
+- If there are no alarms during this period, the deploy was a success.
+- The script will then delete historic versions prior to ten versions ago.
+
+If you do not pass the optional `--file` argument, the `--publish-revision` flag
+will just publish the latest revision of the state machine to the new version
+without first uploading a new definition from a local file.
+
+### CLI inputs
+To get CLI input help, pass `--help`:
+```
+./sfndeploy.py --help
+```
+
+Here is a summary of the inputs:
+```
+❯ ./sfndeploy.py --help
+usage: sfndeploy [-h] --state-machine STATE_MACHINE --alias ALIAS --region REGION
+                 [--strategy {allatonce,canary,linear}] [--alarms [ALARMS ...]]
+                 [--file SM_FILE] [--publish-revision | --no-publish-revision]
+                 [--increment INCREMENT] [--interval INTERVAL]
+                 [--alarm-polling ALARM_POLLING] [--history-max HISTORY_MAX]
+                 [--force | --no-force]
+
+Gradually deploy AWS Step Functions state machines.
+
+options:
+  -h, --help            show this help message and exit
+  --state-machine STATE_MACHINE
+                        Name of the state machine (not ARN).
+  --alias ALIAS         Name of alias.
+  --region REGION       Region name. e.g 'us-east-1'
+  --strategy {allatonce,canary,linear}
+                        The type of deployment to do. By default will deploy AllAtOnce.
+  --alarms [ALARMS ...]
+                        Optional list of CloudWatch alarm names to monitor during
+                        deployment.
+  --file SM_FILE        Optional path to state machine definition file to deploy. Will
+                        upload this file as the latest revision of the state machine. If
+                        you don't set this, will use the current latest revision.
+  --publish-revision, --no-publish-revision
+                        Publish the current revision to the next version.
+  --increment INCREMENT
+                        The increment for weight increase during deploy strategy, from
+                        0-100%. Just input the number, not the % sign.
+  --interval INTERVAL   The interval in seconds at which to increase weight during the
+                        deploy strategy.
+  --alarm-polling ALARM_POLLING
+                        Poll alarms at this interval in seconds. Default 60s.
+  --history-max HISTORY_MAX
+                        Maximum number of versions to keep in history. Will delete
+                        versions older than this. Set to 0 to disable (this is the
+                        default). There is a 1000 version limit in Step Functions.
+  --force, --no-force   Force the deploy to start, even if the alias is not currently
+                        pointing 100% at the old version. This may be required to recover
+                        from a previous deploy that failed and didn't roll back correctly.
+                        This means you might be overwriting an in-progress deploy, or that
+                        something went wrong in a previous deploy. Be careful when
+                        combining with publish_revision - if you just rerun the script you
+                        might force publish a previously uploaded revision without
+                        testing.
+```
+
+### Version History Deletion
+Step Functions limits the number of versions per state machine to 1000. As you
+release new versions of a state machine, the older versions remain in the
+state machine. This can be useful because you might need to rollback to a
+previous version.
+
+To avoid the the build-up of historic versions to reach the limit of 1000, you
+need to trim your version history by deleting older versions once you are sure
+that you do not need them anymore.
+
+This script provides an automatic version history deletion mechanism that runs
+after a deploy completed. You enable this with the `--history-max` argument.
+The script will delete any versions prior to `n` versions ago, where `n` is the
+number you pass to `history-max`.
+
+For example, if you pass `--history-max 5`, the script will only keep five
+versions and delete any versions prior to that.
+
+Carefully consider when a previous version is ready for deletion - you might
+need to rollback to it or to refer to it for auditing purposes. Once you
+delete a state machine version, it is gone forever.
+
+### Alarm Polling Frequency
+By default, the script polls for alarms every 60 seconds. This is because many
+AWS services only have an alarm granularity of 60s.
+
+You can set the polling frequency with the `--alarm-polling argument`.
+For example, set `--alarm-polling 23` and the script will poll all the
+`--alarms` every 23 seconds.
+
+The alarm polling interval is completely independent from `--interval`, so it
+does NOT need to be evenly divisible.
+
+Take care to align how often you poll for alarms with the deployment window
+that you set with `--interval`. If `--alarm-polling` is high relative to
+`--interval` the deployment window could finish before the script polls the
+alarms.
+
+### Script Process Flow
+The script takes the following actions:
+1. If `--file` specified, upload that file as the new revision for the state
+   machine
+2. If `--publish-revision` set, publish the latest revision of the state machine
+   as the next version. This will become the new version to deploy. If you
+   combine this with the `--file` input, this will publish the file you just
+   uploaded as the next version.
+3. Note that if the script fails later on it will NOT undeploy any revision
+   uploaded or promoted to a version in the first two steps.
+   See [Cloudformation](TODO: link here) for provisioning with full rollback.
+4. If `--publish-revision` is not set, the most recent published version of the
+   state machine will deploy. This is useful if you have some other
+   process or tool that updates your state machine definitions, and you just
+   want to use this script as a way to switch the alias from the old version to
+   that new version.
+5. Create the specified alias if it does not exist. If the alias didn't exist,
+   route 100% of traffic to the new version and exit the script. This is because
+   it would be a first deploy, so there is no rollback possible.
+6. Start routing traffic to the alias using the deployment strategy set by
+   `--strategy`. (AllAtOnce, Linear, Canary). The `--increment` and `--interval`
+   arguments govern how the strategy you select behaves.
+7. Monitor any `--alarms` specified during the entire deployment period and
+   rollback automatically if any of these go into ALARM state.
+8. If deployment completes successfully, keep the number of versions set by
+   `history_max` and delete state machine versions prior to that. The default
+   value of 0 for `history_max` disables this deletion of old versions, but
+   remember there is a limit of 1000 versions per state machine.
+
+### Unit tests
+You can run the unit tests for `sfndeploy.py` like this:
+
+```
+python -m unittest sfndeploy_test.py
+```
+
+## AWS CLI example
+This bash script shows how to use AWS CLI commands to do a gradual deployment.
+
+### Prerequisites
+To run [sfn-canary-deploy.sh](sfn-canary-deploy.sh), you will need the
+[AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+installed and configured.
+
+### CLI Script Overview
+[sfn-canary-deploy.sh](sfn-canary-deploy.sh) is a bash script showing how
+to use the AWS CLI to create and manage a Canary-style deployment. For
+AllAtOnce or Linear deployments, see the Python version above.
+
+The script does the following:
+1. Publish the most recent revision as the next version of the state machine if
+   `publish_revision` is true. This will become the new live version.
+2. If `publish_revision` is false, the most recent published version of the
+   state machine will deploy.
+3. Create the alias if it doesn’t exist yet. If the alias didn't exist,
+   point 100% of traffic for this alias to the new version, then exit the
+   script.
+4. Update the routing configuration for the alias to direct a small
+   percentage of traffic from the previous to the new version. You set this
+   canary percentage with `canary_percentage`.
+5. Monitor the configurable CloudWatch alarms every 60s by default. If any of
+   these alarms trigger, rollback the deployment immediately by pointing 100%
+   of traffic to the known-good previous version. Will keep on monitoring the
+   alarms every `alarm_polling_interval` in seconds until
+   `canary_interval_seconds` have passed.
+6. If there were no alarms during the canary interval, shift 100% of traffic to
+   the new version. You set this interval with `canary_interval_seconds`.
+7. Upon successful deployment, delete any versions older than `history_max`.
+
+## Gradual Deployments from CI/CD tools
+Here are some tips to get you started with popular CD platforms:
+
+### Jenkins
+You can run your customized Bash or Python on Jenkins by using the `sh`
+step in the `Jenkinsfile` to run your custom script.
+
+```
+pipeline {
+    agent any
+
+    stages {
+        stage('Build') {
+            steps {
+                echo 'Building..'
+            }
+        }
+        stage('Test') {
+            steps {
+                echo 'Testing..'
+            }
+        }
+        stage(‘Gradual Deploy') {
+            steps {
+                sh /path/to/gradual-deploy-script.sh
+            }
+        }
+    }
+}
+```
+
+You have some options to configure the prequisites: 
+- If you want to run your script directly from the Jenkins pipeline, you must
+  install and configure your prerequisites on the Jenkins server instance - in
+  this case the AWS CLI for the Bash script or Boto3 for the Python script.
+- The Jenkins user must have AWS credentials to access the Step Functions
+  service.
+- If you are using the standard Amazon Machine Image (AMI) as a base for your
+  Jenkins installation this already contains the prequisites.
+- Alternatively, if you want to use custom Docker images to encapsulate your
+  dependencies and scripts, you can use the
+  [Docker Pipeline Plugin](https://plugins.jenkins.io/docker-workflow/) and let
+  [Jenkins run your scripts inside the container](https://www.jenkins.io/doc/pipeline/tour/hello-world/#python).
+
+### Spinnaker
+Use the [Jenkins](https://spinnaker.io/docs/reference/pipeline/stages/#jenkins)
+stage or the [Script](https://spinnaker.io/docs/setup/other_config/features/script-stage/)
+stage in Spinnaker to run a custom shell or Python script from your pipeline.
+
+With the Script stage, Spinnaker uses Jenkins to sandbox your scripts, so you
+need to set up a Jenkins instance in order to use it.
+
+In your Spinnaker deck, select:
+- Add Stage.
+- Select the `Script` type of stage.
+- Under `Command` enter your script invocation.
+- Set `Depends On` if there’s a preceding stage that should run before your
+  custom script.
+
+Alternatively, you can encapsulate your logic and its dependencies in a
+container and execute it with a
+[Run Job stage](https://spinnaker.io/docs/guides/user/kubernetes-v2/run-job-manifest/).
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gradual-deploy
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      containers:
+        - command:
+            - python
+            - path/to/my/script.py
+          image: 'myrepo/mycontainer:1.2.3'
+          name: my-custom-script
+      restartPolicy: Never
+```
+
+## Warning
+Remember that creating and running resources in AWS costs money. Take care to
+delete resources when you're done to avoid billing surprises.
+
+All the scripts in this repo are examples that are not meant for production
+systems. The scripts here do not clean up or release resources when finished.
+Take care & run at your own risk.

--- a/gradual-deploy/sfn-canary-deploy.sh
+++ b/gradual-deploy/sfn-canary-deploy.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# 
+# AWS StepFunctions example showing how to create a canary deployment with a
+# State Machine Alias and versions.
+# 
+# Requirements: AWS CLI installed and credentials configured.
+# 
+# A canary deployment deploys the new version alongside the old version, while
+# routing only a small fraction of the overall traffic to the new version to
+# see if there are any errors. Only once the new version has cleared a testing
+# period will it start receiving 100% of traffic.
+# 
+# For a Blue/Green or All at Once style deployment, you can set the
+# canary_percentage to 100. The script will immediately shift 100% of traffic
+# to the new version, but keep on monitoring the alarms (if any) during the
+# canary_interval_seconds time interval. If any alarms raise during this period,
+# the script will automatically rollback to the previous version.
+# 
+# Step Functions allow you to keep a maximum of 1000 versions in version history
+# for a state machine. This script has a version history deletion mechanism at
+# the end, where it will delete any versions older than the limit specified.
+# 
+# For a fuller example, that also demonstrates linear (or rolling) deployments,
+# please see
+# https://github.com/aws-samples/aws-stepfunctions-examples/gradual-deployments/sfndeploy.py
+
+set -euo pipefail
+
+# ******************************************************************************
+# you can safely change the variables in this block to your values
+state_machine_name="my-state-machine"
+alias_name="alias-1"
+region="us-east-1"
+
+# array of cloudwatch alarms to poll during the test period.
+# to disable alarm checking, set alarm_names=()
+alarm_names=("alarm1" "alarm name with a space")
+
+# true to publish the current revision as the next version before deploy.
+# false to deploy the latest version from the state machine's version history.
+publish_revision=true
+
+# true to force routing configuration update even if the current routing
+# for the alias does not have a 100% routing config.
+# false will abandon deploy attempt if current routing config not 100% to a
+# single version.
+# Be careful when you combine this flag with publish_revision - if you just
+# rerun the script you might deploy the newly published revision from the
+# previous run.
+force=false
+
+# percentage of traffic to route to the new version during the test period
+canary_percentage=10
+
+# how many seconds the canary deployment lasts before full deploy to 100%
+canary_interval_seconds=300
+
+# how often to poll the alarms
+alarm_polling_interval=60
+
+# how many versions to keep in history. delete versions prior to this.
+# set to 0 to disable old version history deletion.
+history_max=0
+# ******************************************************************************
+
+#######################################
+# Update alias routing configuration.
+# 
+# If you don't specify version 2 details, will only create 1 routing entry. In
+# this case the routing entry weight must be 100.
+# 
+# Globals:
+#   alias_arn
+# Arguments:
+#   1. version 1 arn
+#   2. version 1 weight
+#   3. version 2 arn (optional)
+#   4. version 2 weight (optional)
+#######################################
+function update_routing() {
+  if [[ $# -eq 2 ]]; then
+    local routing_config="[{\"stateMachineVersionArn\": \"$1\", \"weight\":$2}]"
+  elif [[ $# -eq 4 ]]; then
+    local routing_config="[{\"stateMachineVersionArn\": \"$1\", \"weight\":$2}, {\"stateMachineVersionArn\": \"$3\", \"weight\":$4}]"
+  else
+    echo "You have to call update_routing with either 2 or 4 input arguments." >&2
+    exit 1
+  fi
+  
+  ${aws} update-state-machine-alias --state-machine-alias-arn ${alias_arn} --routing-configuration "${routing_config}"
+}
+
+# ******************************************************************************
+# pre-run validation
+if [[ (("${#alarm_names[@]}" -gt 0)) ]]; then
+  alarm_exists_count=$(aws cloudwatch describe-alarms --alarm-names "${alarm_names[@]}" --alarm-types "CompositeAlarm" "MetricAlarm" --query "length([MetricAlarms, CompositeAlarms][])" --output text)
+
+  if [[ (("${#alarm_names[@]}" -ne "${alarm_exists_count}")) ]]; then
+    echo All of the alarms to monitor do not exist in CloudWatch: $(IFS=,; echo "${alarm_names[*]}") >&2
+    echo Only the following alarm names exist in CloudWatch:
+    aws cloudwatch describe-alarms --alarm-names "${alarm_names[@]}" --alarm-types "CompositeAlarm" "MetricAlarm" --query "join(', ', [MetricAlarms, CompositeAlarms][].AlarmName)" --output text
+    exit 1
+  fi
+fi
+
+if [[ (("${history_max}" -gt 0)) && (("${history_max}" -lt 2)) ]]; then
+  echo The minimum value for history_max is 2. This is the minimum number of older state machine versions to be able to rollback in the future. >&2
+  exit 1
+fi
+# ******************************************************************************
+# main block follows
+
+account_id=$(aws sts get-caller-identity --query Account --output text)
+
+sm_arn="arn:aws:states:${region}:${account_id}:stateMachine:${state_machine_name}"
+
+# the aws command we'll be invoking a lot throughout.
+aws="aws stepfunctions"
+
+# promote the latest revision to the next version
+if [[ "${publish_revision}" = true ]]; then
+  new_version=$(${aws} publish-state-machine-version --state-machine-arn=$sm_arn --query stateMachineVersionArn --output text)
+  echo Published the current revision of state machine as the next version with arn: ${new_version}
+else
+  new_version=$(${aws} list-state-machine-versions --state-machine-arn ${sm_arn} --max-results 1 --query "stateMachineVersions[0].stateMachineVersionArn" --output text)
+  echo "Since publish_revision is false, using the latest version from the state machine's version history: ${new_version}"
+fi
+
+# find the alias if it exists
+alias_arn_expected="${sm_arn}:${alias_name}"
+alias_arn=$(${aws} list-state-machine-aliases --state-machine-arn ${sm_arn} --query "stateMachineAliases[?stateMachineAliasArn==\`${alias_arn_expected}\`].stateMachineAliasArn" --output text)
+
+if [[ "${alias_arn_expected}" == "${alias_arn}" ]]; then
+  echo Found alias ${alias_arn}
+
+  echo Current routing configuration is:
+  ${aws} describe-state-machine-alias --state-machine-alias-arn "${alias_arn}" --query routingConfiguration
+else
+  echo Alias does not exist. Creating alias ${alias_arn_expected} and routing 100% traffic to new version ${new_version}
+  
+  ${aws} create-state-machine-alias --name "${alias_name}" --routing-configuration "[{\"stateMachineVersionArn\": \"${new_version}\", \"weight\":100}]"
+
+  echo Done!
+  exit 0
+fi
+
+# find the version to which the alias currently points (the current live version)
+old_version=$(${aws} describe-state-machine-alias --state-machine-alias-arn $alias_arn --query "routingConfiguration[?weight==\`100\`].stateMachineVersionArn" --output text)
+
+if [[ -z "${old_version}" ]]; then
+  if [[ "${force}" = true ]]; then
+    echo Force setting is true. Will force update to routing config for alias to point 100% to new version.
+    update_routing "${new_version}" 100
+    
+    echo Alias ${alias_arn} now pointing 100% to ${new_version}.
+    echo Done!
+    exit 0
+  else
+    echo Alias ${alias_arn} does not have a routing config entry with 100% of the traffic. This means there might be a deploy in progress, so not starting another deploy at this time. >&2
+    exit 1
+  fi
+fi
+
+if [[ "${old_version}" == "${new_version}" ]]; then
+  echo The alias already points to this version. No update necessary.
+  exit 0
+fi
+
+echo Switching ${canary_percentage}% to new version ${new_version}
+(( old_weight = 100 - ${canary_percentage} ))
+update_routing "${new_version}" ${canary_percentage} "${old_version}" ${old_weight}
+
+echo New version receiving ${canary_percentage}% of traffic.
+echo Old version ${old_version} is still receiving ${old_weight}%.
+
+if [[ ${#alarm_names[@]} -eq 0 ]]; then
+  echo No alarm_names set. Skipping cloudwatch monitoring.
+  echo Will sleep for ${canary_interval_seconds} seconds before routing 100% to new version.
+  sleep ${canary_interval_seconds}
+  echo Canary period complete. Switching 100% of traffic to new version...
+else
+  echo Checking if alarms fire for the next ${canary_interval_seconds} seconds.
+
+  (( total_wait = canary_interval_seconds + $(date +%s) ))
+
+  now=$(date +%s)
+  while [[ ((${now} -lt ${total_wait})) ]]; do
+    alarm_result=$(aws cloudwatch describe-alarms --alarm-names "${alarm_names[@]}" --state-value ALARM --alarm-types "CompositeAlarm" "MetricAlarm" --query "join(', ', [MetricAlarms, CompositeAlarms][].AlarmName)" --output text)
+
+    if [[ ! -z "${alarm_result}" ]]; then
+      echo The following alarms are in ALARM state: ${alarm_result}. Rolling back deploy. >&2
+      update_routing "${old_version}" 100
+
+      echo Rolled back to ${old_version}
+      exit 1
+    fi
+  
+    echo Monitoring alarms...no alarms have triggered.
+    sleep ${alarm_polling_interval}
+    now=$(date +%s)
+  done
+
+  echo No alarms detected during canary period. Switching 100% of traffic to new version...
+fi
+
+update_routing "${new_version}" 100
+
+echo Version ${new_version} is now receiving 100% of traffic.
+
+if [[ (("${history_max}" -eq 0 ))]]; then
+  echo Version History deletion is disabled. Remember to prune your history, the default limit is 1000 versions.
+  echo Done!
+  exit 0
+fi
+
+echo Keep the last ${history_max} versions. Deleting any versions older than that...
+
+# the results are sorted in descending order of the version creation time
+version_history=$(${aws} list-state-machine-versions --state-machine-arn ${sm_arn} --max-results 1000 --query "join(\`\"\\n\"\`, stateMachineVersions[].stateMachineVersionArn)" --output text)
+
+counter=0
+
+while read line; do
+  ((counter=${counter} + 1))
+
+  if [[ (( ${counter} -gt ${history_max})) ]]; then
+    echo Deleting old version ${line}
+    ${aws} delete-state-machine-version --state-machine-version-arn ${line}
+  fi
+done <<< "${version_history}"
+
+echo Done!

--- a/gradual-deploy/sfndeploy.py
+++ b/gradual-deploy/sfndeploy.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python3
+"""Create gradual deployment of an AWS Step Functions state machine.
+
+Uses an Alias to deploy a new version of state machine, with one of the
+following deployment strategies:
+- All At Once (aka blue/green)
+- Canary
+- Linear
+
+You can set a configurable monitoring period during which the script will
+check CloudWatch alarms and roll-back to the previous version automatically
+if any of the alarms sound.
+
+If you're just getting started, scroll down to the main() function to get your
+bearings.
+
+You can run this script directly from the CLI like this:
+./sfndeploy.py --state-machine my-state-machine --region us-east-1 --alias=my-alias --strategy allatonce --interval=10 --alarms alarm1 "alarm name with a space"
+
+"""
+from __future__ import annotations
+from abc import ABC, abstractmethod
+import argparse
+import os
+import sys
+import time
+from typing import Union
+
+import boto3
+
+stepfunctions = boto3.client('stepfunctions')
+
+
+PathType = Union[str, bytes, os.PathLike]
+
+
+class VersionManager():
+    """Manage State Machine version & releases with aliases."""
+    sts = boto3.client('sts')
+
+    def __init__(self,
+                 state_machine_name: str,
+                 region: str,
+                 account_id: str) -> None:
+        """Use the create() factory to create an instance easily."""
+        self.state_machine_arn = f'arn:aws:states:{region}:{account_id}:stateMachine:{state_machine_name}'
+
+    @classmethod
+    def create(cls, state_machine_name: str, region: str) -> VersionManager:
+        """Create an instance of this class."""
+        account_id = VersionManager.sts.get_caller_identity()['Account']
+
+        return cls(state_machine_name=state_machine_name,
+                   region=region,
+                   account_id=account_id)
+
+    def create_alias(self, name: str, version_arn: str) -> None:
+        """Create alias and point 100% traffic to version_arn."""
+        print(
+            f"Alias {name} not found. Creating it now and pointing " +
+            "100% traffic to it...")
+
+        new_alias = stepfunctions.create_state_machine_alias(
+            name=name,
+            routingConfiguration=[
+                {'stateMachineVersionArn': version_arn,
+                 'weight': 100}
+            ]
+        )
+
+        print(
+            f"Created new alias {new_alias['stateMachineAliasArn']}, " +
+            "routing 100% of traffic to state machine version " +
+            f"{version_arn}.\n" +
+            "Since this is the 1st version for this alias, no rollback possible.")
+
+    def get_latest_published_version(self) -> str | None:
+        """Get the arn of the latest published version of the state machine.
+
+        Returns:
+            Arn of the latest published version, or None if state machine does
+            not have any published versions.
+        """
+        versions_response = stepfunctions.list_state_machine_versions(
+            stateMachineArn=self.state_machine_arn)
+
+        # key exists even if state machine has no published versions - value []
+        version_arns = versions_response['stateMachineVersions']
+
+        if not version_arns:
+            return None
+
+        # versions list is in descending order
+        return version_arns[0]['stateMachineVersionArn']
+
+    def get_new_version_arn(self, publish_revision: bool) -> str:
+        """Get the latest version for this state machine."""
+        if publish_revision:
+            print("Publishing current revision to new version...")
+            # promote the current revision to a published version
+            new_version = stepfunctions.publish_state_machine_version(
+                stateMachineArn=self.state_machine_arn)
+
+            new_version_arn = new_version['stateMachineVersionArn']
+
+            print("Current revision published as next version.")
+        else:
+            new_version_arn = self.get_latest_published_version()
+
+            if not new_version_arn:
+                raise Exception(
+                    "There is no published version for "
+                    f"{self.state_machine_arn}. You need at least one " +
+                    "published version to create an alias.")
+
+        print(f"New state machine version to release is {new_version_arn}")
+        return new_version_arn
+
+    def get_old_version_arn(self, alias: dict) -> str | None:
+        """Get the version arn with 100% weight."""
+        old_version_arn: str | None = None
+
+        for routing in alias['routingConfiguration']:
+            # sfn api enforces that sum of weights == 100
+            if routing['weight'] == 100:
+                old_version_arn = routing['stateMachineVersionArn']
+                print("Old state machine version that is still live " +
+                      f"is {old_version_arn}")
+                break
+
+        return old_version_arn
+
+    def delete_old_versions(self, history_max=500) -> None:
+        """Delete versions older prior to history_max versions ago."""
+        if history_max == 0:
+            print("Version History pruning disabled.")
+            return
+
+        if history_max < 3:
+            ValueError(f"history_max must be > 2. This is the least amount " +
+                       "of version history you need to be able to roll back " +
+                       "in the future.")
+
+        versions_response = stepfunctions.list_state_machine_versions(
+            stateMachineArn=self.state_machine_arn,
+            maxResults=1000)
+
+        # key exists even if state machine has no published versions - value []
+        version_arns = versions_response['stateMachineVersions']
+
+        if len(version_arns) > history_max:
+            print(
+                f"Deleting version history older than {history_max} " +
+                "versions ago...")
+
+            # versions list in descending order
+            for i, version in enumerate(version_arns):
+                if i > history_max:
+                    version_arn = version['stateMachineVersionArn']
+                    stepfunctions.delete_state_machine_version(
+                        stateMachineVersionArn=version_arn)
+                    print(f"Deleted old version {version_arn}")
+        else:
+            print(
+                f"{len(version_arns)} state machines in version history. " +
+                "No version history deletion history necessary, because " +
+                f"{history_max=}.")
+
+    def switch_to_new_version(self,
+                              alias_name: str,
+                              deployer: DeployStrategy,
+                              alarm_checker: AlarmChecker,
+                              publish_revision: bool = True,
+                              history_max: int = 500,
+                              force: bool = False) -> None:
+        """Deploy gradually from previous state machine version to new version.
+
+        Args:
+            alias_name (str): Short name of the alias.
+            deployer (DeployStrategy): Shift traffic with this deploy strategy.
+            alarmchecker (AlarmChecker): Alarms to monitor during
+                                         deploy.
+            publish_revision (bool): Default True. Publish latest revision to
+                                     new version.
+            history_max (int): Default 500. Delete versions prior to history
+                               max from version history upon successful deploy.
+            force (bool): Default False. Force update to alias routing config
+                          even when the current configuration is still in a
+                          transitional state and does not have a 100% routing.
+        """
+        state_machine_arn = self.state_machine_arn
+
+        alias_arn = f'{state_machine_arn}:{alias_name}'
+
+        if alarm_checker.has_alarms():
+            alarm_checker.verify()
+            print(f"Will monitor {alarm_checker.alarm_names} during deploy.")
+        else:
+            print("No alarms to monitor during deploy.")
+
+        # find out where the new version to-be is, so can switch traffic to it
+        new_version_arn = self.get_new_version_arn(publish_revision)
+
+        # if there is an existing alias, find the current live version from it
+        try:
+            alias = stepfunctions.describe_state_machine_alias(
+                stateMachineAliasArn=alias_arn)
+            print(f"Alias {alias_arn} already exists.")
+            print("Current routing configuration is: " +
+                  f"{alias['routingConfiguration']}")
+        except stepfunctions.exceptions.ResourceNotFound:
+            self.create_alias(alias_name, new_version_arn)
+            # done here, because new alias already receiving 100% traffic
+            print("Done.")
+            return
+
+        old_version_arn = self.get_old_version_arn(alias)
+
+        if not old_version_arn:
+            msg = (f"Alias {alias_arn} does not have a routing config entry" +
+                   "with 100 % of the traffic.")
+            print(msg)
+
+            if force:
+                print(
+                    "Force override is True. Will force update to routing " +
+                    "config for alias to point 100% to new version.")
+
+                stepfunctions.update_state_machine_alias(
+                    stateMachineAliasArn=alias_arn,
+                    routingConfiguration=[
+                        {'stateMachineVersionArn': new_version_arn,
+                         'weight': 100}])
+
+                print(f"Alias {alias_arn} now pointing 100% to version " +
+                      "{new_version_arn}.")
+                print("Done")
+                return
+            else:
+                err = (
+                    f"{msg}\nThis means there might be a deploy already in "
+                    "progress, so not starting another deploy at this time.")
+                raise Exception(err)
+
+        if old_version_arn == new_version_arn:
+            print(
+                f"The alias {alias_arn} already points to {old_version_arn}. " +
+                f"No update necessary.")
+            return
+
+        print(f"Deploying {alias_arn}, shifting from {old_version_arn} to " +
+              f"{new_version_arn}")
+
+        alias = Alias(alias_arn=alias_arn,
+                      new_version_arn=new_version_arn,
+                      old_version_arn=old_version_arn)
+
+        deployer.deploy(alias, alarm_checker)
+
+        self.delete_old_versions(history_max)
+
+        print("Done.")
+
+    def upload_revision(self, revision_file_path: PathType) -> None:
+        """Upload the file as the latest revision of the state machine."""
+        with open(revision_file_path) as file:
+            stepfunctions.update_state_machine(
+                stateMachineArn=self.state_machine_arn,
+                definition=file.read())
+            print(
+                f"Uploaded {revision_file_path} as latest revision " +
+                f"for {self.state_machine_arn}")
+
+
+class AlarmChecker():
+    """Monitor alarms during deployment window.
+
+    Attributes:
+        alarm_names (list[str]): List of alarm names to monitor.
+        poll_interval (int): Check alarms at this interval in seconds.
+    """
+    cloudwatch = boto3.client('cloudwatch')
+
+    def __init__(self,
+                 alarm_names: list[str] | None,
+                 poll_interval: int = 60,
+                 raise_err_on_rollback: bool = True) -> None:
+        self.alarm_names: list[str] | None = alarm_names
+        self.poll_interval: int = poll_interval
+        self.raise_err_on_rollback: bool = raise_err_on_rollback
+
+    def check_alarms(self, alias: Alias, duration: int) -> None:
+        """Monitor alarms for duration, rollback if alarm condition."""
+        if not self.alarm_names:
+            print(f"No alarm names to monitor. Sleeping for {duration}s.")
+            time.sleep(duration)
+            return
+
+        interval = self.poll_interval
+
+        if interval > duration:
+            print(f"Warning: Alarm checking interval {interval} is greater " +
+                  f"than deploy {duration}")
+
+        start = time.monotonic()
+
+        while (time.monotonic() - start) < duration:
+            if self.is_alarmed():
+                alias.rollback(raise_err=self.raise_err_on_rollback)
+
+            print("Monitoring alarms...no alarms have triggered.")
+            time.sleep(interval)
+
+    def has_alarms(self) -> bool:
+        """True if there are alarm names to check"""
+        return bool(self.alarm_names)
+
+    def is_alarmed(self) -> bool:
+        """"Return True if any of the alarms triggered."""
+        alarm_response = self.cloudwatch.describe_alarms(
+            AlarmNames=self.alarm_names,
+            StateValue='ALARM')
+
+        metric = alarm_response.get('MetricAlarms', [])
+        composite = alarm_response.get('CompositeAlarms', [])
+
+        is_in_alarm = composite or metric
+
+        if is_in_alarm:
+            active_alarms = []
+            active_alarms.extend(alarm['AlarmName'] for alarm in metric)
+            active_alarms.extend(alarm['AlarmName'] for alarm in composite)
+
+            triggered = ', '.join(active_alarms)
+            print(
+                f"The following alarms triggered: {triggered}", file=sys.stderr)
+
+        return is_in_alarm
+
+    def verify(self) -> None:
+        """Raises error if any alarm_names do not exist on CloudWatch."""
+        # This necessary because describe_alarms does not raise err if alarms
+        # don't exist.
+        alarm_response = self.cloudwatch.describe_alarms(
+            AlarmNames=self.alarm_names)
+
+        metric = alarm_response.get('MetricAlarms', [])
+        composite = alarm_response.get('CompositeAlarms', [])
+
+        existing_alarms = []
+        existing_alarms.extend(alarm['AlarmName'] for alarm in metric)
+        existing_alarms.extend(alarm['AlarmName'] for alarm in composite)
+
+        missing = []
+        for alarm_name in self.alarm_names:
+            if alarm_name not in existing_alarms:
+                missing.append(alarm_name)
+
+        if missing:
+            raise Exception(f'Alarms {missing} do not exist in CloudWatch.')
+
+
+class Alias():
+    """Alias manages routing configuration from old to new version."""
+
+    def __init__(self,
+                 alias_arn: str,
+                 new_version_arn: str,
+                 old_version_arn: str) -> None:
+        self.alias_arn: str = alias_arn
+        self.new_version_arn: str = new_version_arn
+        self.old_version_arn: str = old_version_arn
+
+    def update_weights(self, old_weight: int, new_weight: int) -> None:
+        """Set old version to old_weight, new version to new weight."""
+        stepfunctions.update_state_machine_alias(
+            stateMachineAliasArn=self.alias_arn,
+            routingConfiguration=[
+                {'stateMachineVersionArn': self.old_version_arn,
+                 'weight': old_weight},
+                {'stateMachineVersionArn': self.new_version_arn,
+                 'weight': new_weight}])
+
+        print(f"Updated weights for {self.alias_arn}:")
+        print(f"old version: {old_weight}, new version: {new_weight}")
+
+    def rollback(self, raise_err: bool = True) -> None:
+        """Reset alias routing configuration to point 100% to old version."""
+        print("Rolling back...")
+
+        alias_arn = self.alias_arn
+        old_version_arn = self.old_version_arn
+
+        stepfunctions.update_state_machine_alias(
+            stateMachineAliasArn=alias_arn,
+            routingConfiguration=[
+                {'stateMachineVersionArn': old_version_arn,
+                    'weight': 100}])
+
+        print(f"{old_version_arn} back to receiving 100% traffic.")
+
+        if raise_err:
+            raise Exception(
+                f"Deployment of new version {self.new_version_arn} failed. "
+                "Successfully rolled back alias " +
+                f"{alias_arn} to point at old version {old_version_arn}.")
+
+# region Deploy Strategies
+
+
+class DeployStrategy(ABC):
+    """Derive all deploy strategies from me.
+
+    Attributes:
+        increment (int): Shift traffic by increment at every interval.
+        interval (int): At each interval (in minutes) shift traffic by
+                        increment value.
+    """
+
+    def __init__(self,
+                 increment: int,
+                 interval: int) -> None:
+        if increment < 1:
+            raise ValueError("increment must be >1.")
+        if increment > 100:
+            raise ValueError("increment must be <=100.")
+
+        self.increment = increment
+        self.interval = interval
+
+    @abstractmethod
+    def deploy(self, alias: Alias, alarm_checker: AlarmChecker) -> None:
+        pass
+
+
+class Linear(DeployStrategy):
+    """Rolling deploy that spreads increment evenly over duration."""
+
+    def deploy(self, alias: Alias, alarm_checker: AlarmChecker) -> None:
+        """Shift traffic from old to new in even linear increments."""
+        increment = self.increment
+        interval = self.interval
+        new_weight = 0
+
+        duration = (100 / increment) * interval
+
+        print("Linear Deploy Strategy beginning...")
+        print(f"Will move {increment}% of traffic to new version every "
+              f"{interval}s over a total " +
+              f"elapsed time of {duration}s")
+        while new_weight < 100:
+            new_weight = new_weight + increment
+            if new_weight > 100:
+                new_weight = 100
+
+            old_weight = 100 - new_weight
+            alias.update_weights(old_weight=old_weight, new_weight=new_weight)
+
+            # sleep between weight updates happens in check_alarms
+            alarm_checker.check_alarms(alias, interval)
+
+
+class Canary(DeployStrategy):
+    """Move traffic in 2 steps - 1st a % for a test interval, and then all."""
+
+    def deploy(self, alias: Alias, alarm_checker: AlarmChecker) -> None:
+        """Shift traffic from old to new in 2 increments."""
+        increment = self.increment
+
+        print("Canary deploy strategy beginning...")
+        print(f"Will move {increment}% of traffic to new version initially " +
+              f"and monitor for {self.interval}s.")
+
+        alias.update_weights(old_weight=100-increment, new_weight=increment)
+
+        # monitor alarms for specified period and rollback if appropriate.
+        alarm_checker.check_alarms(alias, self.interval)
+
+        if increment == 100:
+            print("Canary increment was 100, no second increment required.")
+        else:
+            print(
+                "Canary testing period complete. Switching 100% to new version.")
+            alias.update_weights(old_weight=0, new_weight=100)
+
+
+class AllAtOnce(DeployStrategy):
+    """Move 100% traffic to new version immediately (blue/green)."""
+
+    def deploy(self, alias: Alias, alarm_checker: AlarmChecker) -> None:
+        """Shift traffic from old to new immediately."""
+        print("All At Once deploy strategy beginning...")
+        print(f"Will move 100% of traffic to new version immediately " +
+              f"and monitor for {self.interval}s.")
+
+        alias.update_weights(old_weight=0, new_weight=100)
+
+        alarm_checker.check_alarms(alias, self.interval)
+
+        print("Alarm monitoring period complete. No issues!")
+
+
+deploy_strategy_object_mapping = {
+    'allatonce': AllAtOnce,
+    'canary': Canary,
+    'linear': Linear,
+}
+# endregion Deploy Strategies
+
+
+# region cli
+def get_parsed_args(args):
+    """Get cli input args."""
+    description = 'Gradually deploy AWS Step Functions state machines.'
+    parser = argparse.ArgumentParser(prog='sfndeploy',
+                                     description=description,
+                                     allow_abbrev=True)
+
+    # required
+    parser.add_argument('--state-machine',
+                        dest='state_machine',
+                        required=True,
+                        help="Name of the state machine (not ARN).")
+    parser.add_argument('--alias', dest='alias', required=True,
+                        help="Name of alias.")
+    parser.add_argument('--region', dest='region', required=True,
+                        help="Region name. e.g 'us-east-1'")
+
+    # optional
+    strategy_help = (
+        "The type of deployment to do. By default will deploy AllAtOnce.")
+    parser.add_argument('--strategy',
+                        dest='strategy',
+                        choices=['allatonce', 'canary', 'linear'],
+                        type=str.lower,
+                        default='allatonce',
+                        help=strategy_help)
+
+    alarm_help = (
+        "Optional list of CloudWatch alarm names to monitor during deployment.")
+    parser.add_argument('--alarms', nargs='*', dest='alarms',
+                        help=alarm_help)
+
+    file_help = (
+        "Optional path to state machine definition file to deploy.\n" +
+        "Will upload this file as the latest revision of the state machine. " +
+        "If you don't set this, will use the current latest revision.")
+
+    parser.add_argument('--file', dest='sm_file',
+                        help=file_help)
+
+    revision_help = "Publish the current revision to the next version."
+    parser.add_argument('--publish-revision',
+                        action=argparse.BooleanOptionalAction,
+                        dest='publish_revision',
+                        help=revision_help)
+
+    increment_help = (
+        "The increment for weight increase during deploy strategy, from " +
+        "0-100%%. Just input the number, not the %% sign.")
+    parser.add_argument('--increment', type=int,
+                        default=5,
+                        dest='increment',
+                        help=increment_help)
+
+    interval_help = (
+        "The interval in seconds at which to increase weight during the " +
+        "deploy strategy.")
+
+    parser.add_argument('--interval', type=int, default=120, dest='interval',
+                        help=interval_help)
+
+    parser.add_argument('--alarm-polling', type=int, default=60,
+                        dest='alarm_polling',
+                        help=(
+                            'Poll alarms at this interval in seconds. ' +
+                            'Default 60s.'))
+
+    history_help = (
+        "Maximum number of versions to keep in history.\n" +
+        "Will delete versions older than this.\n" +
+        "Set to 0 to disable (this is the default).\n" +
+        "There is a 1000 version limit in Step Functions.")
+    parser.add_argument('--history-max', type=int, default=0,
+                        dest='history_max',
+                        help=history_help
+                        )
+
+    force_help = (
+        "Force the deploy to start, even if the alias is not currently " +
+        "pointing 100%% at the old version. This may be required to recover " +
+        "from a previous deploy that failed and didn't roll back correctly.\n" +
+        "This means you might be overwriting an in-progress deploy, or that " +
+        "something went wrong in a previous deploy.\n" +
+        "Be careful when combining with publish_revision - if you just " +
+        "rerun the script you might force publish a previously uploaded " +
+        "revision without testing.")
+
+    parser.add_argument('--force', action=argparse.BooleanOptionalAction,
+                        dest='force',
+                        help=force_help)
+
+    args = parser.parse_args(args)
+
+    return args
+
+# endregion cli
+
+
+def main(args=None) -> int:
+    """Entry point for Step Functions Gradual Deployments script."""
+    if args is None:
+        args = sys.argv[1:]
+
+    parsed_args = get_parsed_args(args)
+
+    strategy_key = parsed_args.strategy.lower()
+    strategy_class = deploy_strategy_object_mapping[strategy_key]
+    deployer = strategy_class(increment=parsed_args.increment,
+                              interval=parsed_args.interval)
+
+    alarm_checker = AlarmChecker(alarm_names=parsed_args.alarms,
+                                 poll_interval=parsed_args.interval)
+
+    version_manager = VersionManager.create(
+        state_machine_name=parsed_args.state_machine,
+        region=parsed_args.region)
+
+    sm_file_path = parsed_args.sm_file
+    if sm_file_path:
+        version_manager.upload_revision(sm_file_path)
+
+    version_manager.switch_to_new_version(
+        alias_name=parsed_args.alias,
+        deployer=deployer,
+        alarm_checker=alarm_checker,
+        publish_revision=parsed_args.publish_revision,
+        history_max=parsed_args.history_max,
+        force=parsed_args.force)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/gradual-deploy/sfndeploy_test.py
+++ b/gradual-deploy/sfndeploy_test.py
@@ -1,0 +1,161 @@
+"""Unit tests for sfndeploy.py
+
+As an end-user this module is not relevant to you. You do not need to copy it
+alongside sfndeploy.py.
+
+If you are coding changes to sfndeploy.py, this test module is useful during
+the development phase.
+"""
+import unittest
+from unittest.mock import call, patch, MagicMock
+
+import sfndeploy
+
+
+class LinearTests(unittest.TestCase):
+
+    def test_linear_increment_10_interval_10(self):
+        alias_mock = MagicMock()
+        alarm_mock = MagicMock()
+
+        linear = sfndeploy.Linear(increment=10, interval=10)
+        linear.deploy(alias=alias_mock, alarm_checker=alarm_mock)
+
+        self.assertEqual(alias_mock.update_weights.mock_calls,
+                         [
+                             call(old_weight=90, new_weight=10),
+                             call(old_weight=80, new_weight=20),
+                             call(old_weight=70, new_weight=30),
+                             call(old_weight=60, new_weight=40),
+                             call(old_weight=50, new_weight=50),
+                             call(old_weight=40, new_weight=60),
+                             call(old_weight=30, new_weight=70),
+                             call(old_weight=20, new_weight=80),
+                             call(old_weight=10, new_weight=90),
+                             call(old_weight=0, new_weight=100)])
+
+        self.assertEqual(alarm_mock.check_alarms.mock_calls,
+                         [call(alias_mock, 10),
+                          call(alias_mock, 10),
+                          call(alias_mock, 10),
+                          call(alias_mock, 10),
+                          call(alias_mock, 10),
+                          call(alias_mock, 10),
+                          call(alias_mock, 10),
+                          call(alias_mock, 10),
+                          call(alias_mock, 10),
+                          call(alias_mock, 10)])
+
+    def test_linear_increment_30_interval_12(self):
+        alias_mock = MagicMock()
+        alarm_mock = MagicMock()
+
+        linear = sfndeploy.Linear(increment=30, interval=12)
+        linear.deploy(alias=alias_mock, alarm_checker=alarm_mock)
+
+        self.assertEqual(alias_mock.update_weights.mock_calls,
+                         [
+                             call(old_weight=70, new_weight=30),
+                             call(old_weight=40, new_weight=60),
+                             call(old_weight=10, new_weight=90),
+                             call(old_weight=0, new_weight=100)])
+
+        self.assertEqual(alarm_mock.check_alarms.mock_calls,
+                         [call(alias_mock, 12),
+                          call(alias_mock, 12),
+                          call(alias_mock, 12),
+                          call(alias_mock, 12)])
+
+    def test_linear_increment_90_interval_0(self):
+        alias_mock = MagicMock()
+        alarm_mock = MagicMock()
+
+        linear = sfndeploy.Linear(increment=90, interval=0)
+        linear.deploy(alias=alias_mock, alarm_checker=alarm_mock)
+
+        self.assertEqual(alias_mock.update_weights.mock_calls,
+                         [
+                             call(old_weight=10, new_weight=90),
+                             call(old_weight=0, new_weight=100)])
+
+        self.assertEqual(alarm_mock.check_alarms.mock_calls,
+                         [call(alias_mock, 0),
+                          call(alias_mock, 0)])
+
+    def test_linear_increment_100_interval_0(self):
+        alias_mock = MagicMock()
+        alarm_mock = MagicMock()
+
+        linear = sfndeploy.Linear(increment=100, interval=0)
+        linear.deploy(alias=alias_mock, alarm_checker=alarm_mock)
+
+        self.assertEqual(alias_mock.update_weights.mock_calls,
+                         [
+                             call(old_weight=0, new_weight=100)])
+
+        self.assertEqual(alarm_mock.check_alarms.mock_calls,
+                         [call(alias_mock, 0)])
+
+    def test_linear_increment_500_interval_2(self):
+        with self.assertRaises(ValueError) as err:
+            sfndeploy.Linear(increment=500, interval=2)
+
+        self.assertEqual(str(err.exception), 'increment must be <=100.')
+
+
+class CanaryTests(unittest.TestCase):
+
+    def test_canary_increment_100_interval_2(self):
+        alias_mock = MagicMock()
+        alarm_mock = MagicMock()
+
+        canary = sfndeploy.Canary(increment=100, interval=2)
+        canary.deploy(alias=alias_mock, alarm_checker=alarm_mock)
+
+        self.assertEqual(alias_mock.update_weights.mock_calls,
+                         [
+                             call(old_weight=0, new_weight=100)])
+
+        self.assertEqual(alarm_mock.check_alarms.mock_calls,
+                         [call(alias_mock, 2)])
+
+    def test_canary_increment_10_interval_2(self):
+        alias_mock = MagicMock()
+        alarm_mock = MagicMock()
+
+        canary = sfndeploy.Canary(increment=10, interval=2)
+        canary.deploy(alias=alias_mock, alarm_checker=alarm_mock)
+
+        self.assertEqual(alias_mock.update_weights.mock_calls,
+                         [
+                             call(old_weight=90, new_weight=10),
+                             call(old_weight=0, new_weight=100)])
+
+        self.assertEqual(alarm_mock.check_alarms.mock_calls,
+                         [call(alias_mock, 2)])
+
+    def test_canary_increment_negative_interval_2(self):
+        with self.assertRaises(ValueError) as err:
+            sfndeploy.Canary(increment=-1, interval=2)
+
+        self.assertEqual(str(err.exception), 'increment must be >1.')
+
+
+class AllAtOnceTests(unittest.TestCase):
+
+    def test_all_at_once_interval_2(self):
+        alias_mock = MagicMock()
+        alarm_mock = MagicMock()
+
+        all_at_once = sfndeploy.AllAtOnce(increment=10, interval=2)
+        all_at_once.deploy(alias=alias_mock, alarm_checker=alarm_mock)
+
+        self.assertEqual(alias_mock.update_weights.mock_calls,
+                         [call(old_weight=0, new_weight=100)])
+
+        self.assertEqual(alarm_mock.check_alarms.mock_calls,
+                         [call(alias_mock, 2)])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Examples demonstrating how to do gradual deployments with Step Functions versions and aliases. The examples demonstrate using the Python SDK and the AWS CLI to create your gradual deployments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

