### PR TITLE
correct py link in sh script

### DIFF
--- a/gradual-deploy/sfn-canary-deploy.sh
+++ b/gradual-deploy/sfn-canary-deploy.sh
@@ -22,7 +22,7 @@
 # 
 # For a fuller example, that also demonstrates linear (or rolling) deployments,
 # please see
-# https://github.com/aws-samples/aws-stepfunctions-examples/gradual-deployments/sfndeploy.py
+# https://github.com/aws-samples/aws-stepfunctions-examples/blob/main/gradual-deploy/sfndeploy.py
 
 set -euo pipefail
 


### PR DESCRIPTION
Non-functional change. Just corrects a link in a comment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

